### PR TITLE
Remove requiring of bundler/setup

### DIFF
--- a/bin/honk
+++ b/bin/honk
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require 'bundler/setup'
+
 require 'honk'
 Honk.()


### PR DESCRIPTION
This means the gem can be used without being in another project's gemfile. Thus, no need for `bundle exec` prefix in the docs :)